### PR TITLE
(enhancement) can view children of root node

### DIFF
--- a/PositionStack.go
+++ b/PositionStack.go
@@ -10,7 +10,14 @@ type Position struct {
 }
 
 func (pStack *PositionStack) IsEmpty() bool {
-	return &pStack.Positions == nil
+	return pStack.Size() == 0
+}
+
+func (pStack *PositionStack) Size() int {
+	if &pStack.Positions == nil {
+		return 0
+	}
+	return len(pStack.Positions)
 }
 
 func (pStack *PositionStack) GetLast() *Position {
@@ -20,7 +27,6 @@ func (pStack *PositionStack) GetLast() *Position {
 			Row:   0,
 		}
 	}
-
 	return pStack.GetPosition(pStack.Size() - 1)
 }
 
@@ -31,7 +37,6 @@ func (pStack *PositionStack) GetPosition(depth int) *Position {
 			Row:   0,
 		}
 	}
-
 	return &pStack.Positions[depth]
 }
 
@@ -61,16 +66,8 @@ func (pStack *PositionStack) Push(p Position) {
 }
 
 func (pStack *PositionStack) Pop() {
-	if pStack.Size() == 0 || pStack.IsEmpty() {
+	if pStack.IsEmpty() {
 		return
 	}
-
-	pStack.Positions = pStack.Positions[:pStack.Size() - 1]
-}
-
-func (pStack *PositionStack) Size() int {
-	if pStack.IsEmpty() {
-		return 0
-	}
-	return len(pStack.Positions)
+	pStack.Positions = pStack.Positions[:pStack.Size()-1]
 }

--- a/PositionStack.go
+++ b/PositionStack.go
@@ -1,16 +1,16 @@
 package main
 
+type PositionStack struct {
+	Positions []Position
+}
+
 type Position struct {
 	Depth int
 	Row   int
 }
 
-type PositionStack struct {
-	AllPositions []Position
-}
-
 func (pStack *PositionStack) IsEmpty() bool {
-	return &pStack.AllPositions == nil
+	return &pStack.Positions == nil
 }
 
 func (pStack *PositionStack) GetLast() *Position {
@@ -32,7 +32,7 @@ func (pStack *PositionStack) GetPosition(depth int) *Position {
 		}
 	}
 
-	return &pStack.AllPositions[depth]
+	return &pStack.Positions[depth]
 }
 
 func (pStack *PositionStack) GetRow(depth int) int {
@@ -57,7 +57,7 @@ func (pStack *PositionStack) AddPosition(depth, row int) {
 }
 
 func (pStack *PositionStack) Push(p Position) {
-	pStack.AllPositions = append(pStack.AllPositions, p)
+	pStack.Positions = append(pStack.Positions, p)
 }
 
 func (pStack *PositionStack) Pop() {
@@ -65,12 +65,12 @@ func (pStack *PositionStack) Pop() {
 		return
 	}
 
-	pStack.AllPositions = pStack.AllPositions[:pStack.Size()]
+	pStack.Positions = pStack.Positions[:pStack.Size()]
 }
 
 func (pStack *PositionStack) Size() int {
 	if pStack.IsEmpty() {
 		return 0
 	}
-	return len(pStack.AllPositions) - 1
+	return len(pStack.Positions) - 1
 }

--- a/PositionStack.go
+++ b/PositionStack.go
@@ -21,7 +21,7 @@ func (pStack *PositionStack) GetLast() *Position {
 		}
 	}
 
-	return pStack.GetPosition(pStack.Size())
+	return pStack.GetPosition(pStack.Size() - 1)
 }
 
 func (pStack *PositionStack) GetPosition(depth int) *Position {
@@ -65,12 +65,12 @@ func (pStack *PositionStack) Pop() {
 		return
 	}
 
-	pStack.Positions = pStack.Positions[:pStack.Size()]
+	pStack.Positions = pStack.Positions[:pStack.Size() - 1]
 }
 
 func (pStack *PositionStack) Size() int {
 	if pStack.IsEmpty() {
 		return 0
 	}
-	return len(pStack.Positions) - 1
+	return len(pStack.Positions)
 }

--- a/list.go
+++ b/list.go
@@ -152,7 +152,7 @@ func (i *item) ForEachChild(iteratee TailIteratee) {
 func getCurrentItem(root *item, stack *PositionStack) *item {
 	currentItem := root
 
-	_getCurrentItemIterator(root, stack, func(nextItem *item) {
+	currentItemIterator(root, stack, func(nextItem *item) {
 		currentItem = nextItem
 	})
 
@@ -160,7 +160,7 @@ func getCurrentItem(root *item, stack *PositionStack) *item {
 }
 
 // From root get to last item invoking TreeIteratee on each item
-func _getCurrentItemIterator(root *item, stack *PositionStack, iteratee TreeIteratee) {
+func currentItemIterator(root *item, stack *PositionStack, iteratee TreeIteratee) {
 	_toLastItemInStack(root, stack, iteratee, 0)
 }
 

--- a/list.go
+++ b/list.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 )
 
@@ -14,11 +13,18 @@ type item struct {
 	depth  int
 }
 
+type TreeIteratee func(i *item)
+type TailIteratee func(i *item, idx int)
+
 func (i *item) Print() {
 	fmt.Println("Notes:")
 	for n := range i.Tail {
 		fmt.Printf("\t %v\t%p\n", i.Tail[n].Head, &i.Tail[n])
 	}
+}
+
+func (i *item) IsLeaf() bool {
+	return i.Tail == nil || len(i.Tail) == 0
 }
 
 func (i *item) StringChildren() (s string) {
@@ -127,22 +133,59 @@ func swapItem(tail []item, current, next int) {
 	tail[current], tail[next] = tail[next], tail[current]
 }
 
-func unPack(itemToUnPack *item, cursor int, depth int, currentDepth int) *item {
-	if itemToUnPack == nil {
-		log.Fatal("😱")
+// invoke TreeIteratee on each item in Tail
+func (i *item) ForEachChild(iteratee TailIteratee) {
+	if i.Tail == nil {
+		return
 	}
 
-	if currentDepth == depth {
-		return itemToUnPack
+	for j := 0; j < len(i.Tail); j++ {
+		curItem := &i.Tail[j]
+
+		if curItem != nil {
+			iteratee(curItem, j)
+		}
 	}
-	return unPack(&itemToUnPack.Tail[cursor], cursor, depth, currentDepth+1)
 }
 
-// Implementation always uses root
-func getCurrentItem(root *item, stack *PositionStack, count int) *item {
-	if stack.IsEmpty() || stack.GetLast().Depth == count {
-		return root
-	}
+// Implementation always uses root: "From root, get to current item using the PositionStack"
+func getCurrentItem(root *item, stack *PositionStack) *item {
+	currentItem := root
 
-	return getCurrentItem(&root.Tail[stack.GetRow(count)], stack, count+1)
+	_getCurrentItemIterator(root, stack, func(nextItem *item) {
+		currentItem = nextItem
+	})
+
+	return currentItem
+}
+
+// From root get to last item invoking TreeIteratee on each item
+func _getCurrentItemIterator(root *item, stack *PositionStack, iteratee TreeIteratee) {
+	_toLastItemInStack(root, stack, iteratee, 0)
+}
+
+func _toLastItemInStack(root *item, stack *PositionStack, iteratee TreeIteratee, count int) {
+	if stack.GetLast().Depth == count {
+		iteratee(root)
+	} else {
+		_toLastItemInStack(&root.Tail[stack.GetRow(count)], stack, iteratee, count+1)
+	}
+}
+
+// From current position invoke TreeIteratee on every item
+func traverseTree(root *item, iteratee TreeIteratee) {
+	_traverseTreeIterator(root, iteratee)
+}
+
+// depth first iterates over the entire tree and invokes callback on each item
+func _traverseTreeIterator(root *item, iteratee TreeIteratee) {
+	iteratee(root)
+
+	root.ForEachChild(func(child *item, _ int) {
+		if !child.IsLeaf() {
+			_traverseTreeIterator(child, iteratee)
+		} else {
+			iteratee(child)
+		}
+	})
 }

--- a/list.go
+++ b/list.go
@@ -161,6 +161,7 @@ func getCurrentItem(root *item, stack *PositionStack) *item {
 
 // From root get to last item invoking TreeIteratee on each item
 func currentItemIterator(root *item, stack *PositionStack, iteratee TreeIteratee) {
+	// could set count to a different depth to iterate from -> to other nodes in tree 🤔
 	_toLastItemInStack(root, stack, iteratee, 0)
 }
 

--- a/list.go
+++ b/list.go
@@ -137,3 +137,12 @@ func unPack(itemToUnPack *item, cursor int, depth int, currentDepth int) *item {
 	}
 	return unPack(&itemToUnPack.Tail[cursor], cursor, depth, currentDepth+1)
 }
+
+// Implementation always uses root
+func getCurrentItem(root *item, stack *PositionStack, count int) *item {
+	if stack.IsEmpty() || stack.GetLast().Depth == count {
+		return root
+	}
+
+	return getCurrentItem(&root.Tail[stack.GetRow(count)], stack, count+1)
+}

--- a/main.go
+++ b/main.go
@@ -77,14 +77,16 @@ func main() {
 	row := 0
 	currentItem.Plot(s, &row)
 
-	for {
 
-		//currentItem := unPack(&root, cy, depth, 0)
+	for {
+		currentItem := getCurrentItem(&root, &stack)
 
 		// Block empty tail from existing
 		if len(currentItem.Tail) == 0 {
-			currentItem.Tail = append(currentItem.Tail, item{Parent: currentItem})
-			continue
+			currentItem.Tail = append(currentItem.Tail, item{
+				Parent: currentItem,
+				Head:   "Parent: " + currentItem.Head + ", " + " Depth: " + strconv.Itoa(depth) + " Row: " + strconv.Itoa(cy),
+			})
 		}
 		drawInfo(s, currentItem, c.y, depth)
 		row = 0
@@ -165,8 +167,10 @@ func main() {
 				c.y = 0
 
 			case tcell.KeyLeft:
-				if currentItem.Parent == nil {
-					continue
+				if !currentItem.Home {
+					stack.Pop()
+					depth--
+					cy = stack.GetRow(depth)
 				}
 				stack.Pop()
 				depth--

--- a/main.go
+++ b/main.go
@@ -58,8 +58,6 @@ func main() {
 	white := tcell.StyleDefault.
 		Foreground(tcell.ColorWhite).Background(tcell.ColorRed)
 
-	depth := 0
-
 	mx, my := -1, -1
 	var bstr, lks, mks string
 	X, Y := s.Size()
@@ -169,6 +167,7 @@ func main() {
 				if currentItem.Parent == nil {
 					continue
 				}
+				stack.Pop()
 				depth--
 			case tcell.KeyTab:
 				currentItem.Tail[c.y].Head = "\t" + currentItem.Tail[c.y].Head

--- a/main.go
+++ b/main.go
@@ -77,6 +77,8 @@ func main() {
 	row := 0
 	currentItem.Plot(s, &row)
 
+	stack:=PositionStack{}
+	stack.AddPosition(0 , 0)
 
 	for {
 		currentItem := getCurrentItem(&root, &stack)

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 		y: cy,
 		i: &root,
 	}
+	depth:=0
 	currentItem := &root
 	drawInfo(s, currentItem, c.y, depth)
 	row := 0

--- a/position.go
+++ b/position.go
@@ -1,0 +1,76 @@
+package main
+
+type Position struct {
+	Depth int
+	Row   int
+}
+
+type PositionStack struct {
+	AllPositions []Position
+}
+
+func (pStack *PositionStack) IsEmpty() bool {
+	return &pStack.AllPositions == nil
+}
+
+func (pStack *PositionStack) GetLast() *Position {
+	if pStack.IsEmpty() {
+		return &Position{
+			Depth: 0,
+			Row:   0,
+		}
+	}
+
+	return pStack.GetPosition(pStack.Size())
+}
+
+func (pStack *PositionStack) GetPosition(depth int) *Position {
+	if pStack.IsEmpty() {
+		return &Position{
+			Depth: 0,
+			Row:   0,
+		}
+	}
+
+	return &pStack.AllPositions[depth]
+}
+
+func (pStack *PositionStack) GetRow(depth int) int {
+	if pStack.IsEmpty() {
+		return 0
+	}
+	return pStack.GetPosition(depth).Row
+}
+
+func (pStack *PositionStack) SetRow(depth, row int) {
+	if pStack.IsEmpty() {
+		return
+	}
+	pStack.GetPosition(depth).Row = row
+}
+
+func (pStack *PositionStack) AddPosition(depth, row int) {
+	pStack.Push(Position{
+		Depth: depth,
+		Row:   row,
+	})
+}
+
+func (pStack *PositionStack) Push(p Position) {
+	pStack.AllPositions = append(pStack.AllPositions, p)
+}
+
+func (pStack *PositionStack) Pop() {
+	if pStack.Size() == 0 || pStack.IsEmpty() {
+		return
+	}
+
+	pStack.AllPositions = pStack.AllPositions[:pStack.Size()]
+}
+
+func (pStack *PositionStack) Size() int {
+	if pStack.IsEmpty() {
+		return 0
+	}
+	return len(pStack.AllPositions) - 1
+}


### PR DESCRIPTION
@kepler471 

This implementation "works" but always traverses from `root` where we may not need that as the children of root and etc know the parent I think it is best visualised with this:

![listy-datastructure](https://user-images.githubusercontent.com/29375815/93426556-2f532000-f8b4-11ea-9cdb-dd69924b23a3.png)


